### PR TITLE
C99 compatibility fixes

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -55,6 +55,7 @@
 #include <dnet.h>
 
 #include "interface.h"
+#include "string-compat.h"
 
 /* Prototypes */
 static int pcap_dloff(pcap_t *);

--- a/md5.c
+++ b/md5.c
@@ -29,6 +29,8 @@
 #include "config.h"
 #endif
 
+#include <string.h>
+
 #include "md5.h"
 
 /* Little-endian byte-swapping routines.  Note that these do not

--- a/scanssh.c
+++ b/scanssh.c
@@ -64,6 +64,7 @@
 #include "exclude.h"
 #include "xmalloc.h"
 #include "interface.h"
+#include "string-compat.h"
 
 #ifndef howmany
 #define howmany(x,y)	(((x) + ((y) - 1)) / (y))

--- a/scanssh.h
+++ b/scanssh.h
@@ -28,6 +28,8 @@
 #ifndef _SCANSSH_H_
 #define _SCANSSH_H_
 
+#include <sys/queue.h>
+
 #define SSHMAPVERSION	"SSH-1.0-SSH_Version_Mapper\n"
 #define SSHUSERAGENT	"ScanSSH/2.0"
 #define MAXITER		10

--- a/string-compat.h
+++ b/string-compat.h
@@ -1,0 +1,2 @@
+size_t strlcpy(char *, const char *, size_t);
+size_t strlcat(char *, const char *, size_t);

--- a/strlcat.c
+++ b/strlcat.c
@@ -34,6 +34,7 @@ static char *rcsid = "$OpenBSD: strlcat.c,v 1.1 1998/07/01 01:29:45 millert Exp 
 
 #include <sys/types.h>
 #include <string.h>
+#include "string-compat.h"
 
 /*
  * Appends src to string dst of size siz (unlike strncat, siz is the

--- a/strlcpy.c
+++ b/strlcpy.c
@@ -34,6 +34,7 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.2 1998/11/06 04:33:16 wvdputte Exp
 
 #include <sys/types.h>
 #include <string.h>
+#include "string-compat.h"
 
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "config.h"
+#include "string-compat.h"
 
 void *
 xmalloc(size_t size)


### PR DESCRIPTION
Add a prototypes for the strlcpy, strlcat functions, to avoid an implicit function declaration, via the string-compat.h header file. Otherwise, the package will fail to build with future compilers which no longer support implicit function declarations by default.  Include "string-compat.h" in the source files that call strlcpy or strlcat.

Include <sys/queue.h> to scanssh.h, so that the TAILQ_HEAD macro is defined.  Otherwise “TAILQ_HEAD(socksq, socks_host);“ is parsed as a declaration of a function called TAILQ_HEAD, with implicit ints.

md5.c calls memset and memcpy, so include <string.h> for the prototypes.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
