### PR TITLE
Fix -Wimplicit-function-declaration error with gcc 14.

### DIFF
--- a/arc4random.c
+++ b/arc4random.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "config.h"
 


### PR DESCRIPTION
Error:

```
arc4random.c:19:25: error: implicit declaration of function 'time'
[-Wimplicit-function-declaration]
   19 |                 srandom(time(NULL));
      |                         ^~~~
```