### PR TITLE
config.h.in: drop PACKAGE_* definitions to avoid redefinition warnings

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -169,27 +169,6 @@
 /* Define to 1 if you have the `warnx' function. */
 #undef HAVE_WARNX
 
-/* Name of package */
-#undef PACKAGE
-
-/* Define to the address where bug reports for this package should be sent. */
-#undef PACKAGE_BUGREPORT
-
-/* Define to the full name of this package. */
-#undef PACKAGE_NAME
-
-/* Define to the full name and version of this package. */
-#undef PACKAGE_STRING
-
-/* Define to the one symbol short name of this package. */
-#undef PACKAGE_TARNAME
-
-/* Define to the home page for this package. */
-#undef PACKAGE_URL
-
-/* Define to the version of this package. */
-#undef PACKAGE_VERSION
-
 /* Define as the return type of signal handlers (`int' or `void'). */
 #undef RETSIGTYPE
 


### PR DESCRIPTION
Automake already passes `-DPACKAGE_NAME` etc. from `AC_INIT`. Defining them again in config.h caused `-Wmacro-redefined` when building with Fedora's flags. Remove the `PACKAGE/PACKAGE_*` blocks from `config.h.in` so `config.h` no longer redefines them.

~~~
gcc -DPACKAGE_NAME=\"scanssh\" -DPACKAGE_TARNAME=\"scanssh\" -DPACKAGE_VERSION=\"2.1.3.1\" -DPACKAGE_STRING=\"scanssh\ 2.1.3.1\" -DPACKAGE_BUGREPORT=\"https://github.com/ofalk/scanssh/issues\" -DPACKAGE_URL=\"\" -DPACKAGE=\"scanssh\" -DVERSION=\"2.1.3.1\" -DHAVE_INET_ATON=1 -DHAVE_INET_PTON=1 -DHAVE_STRSEP=1 -DHAVE_GETADDRINFO=1 -DHAVE_GETNAMEINFO=1 -DHAVE_STRLCPY=1 -DHAVE_STRLCAT=1 -DHAVE_ARC4RANDOM=1 -DHAVE_WARNX=1 -DHAVE_SYS_WAIT_H=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_FCNTL_H=1 -DHAVE_SYS_IOCTL_H=1 -DHAVE_SYS_TIME_H=1 -DHAVE_UNISTD_H=1 -DHAVE_FDMASK_IN_SELECT=1 -DHAVE_SOCKADDR_STORAGE=1 -DHAVE_STRUCT_ADDRINFO=1 -DHAVE_TIMERADD=1 -DHAVE_GETTIMEOFDAY=1 -DHAVE_SELECT=1 -DHAVE_SOCKET=1 -DHAVE_STRDUP=1 -DHAVE_STRERROR=1 -DHAVE_STRTOL=1 -DHAVE_SETEUID=1 -I.  -I./ -I./compat -I/usr/include -I/usr/include    -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer    -I/usr/include -c -o atomicio.o atomicio.c
In file included from atomicio.c:31:
config.h:177:9: warning: ‘PACKAGE_BUGREPORT’ redefined
  177 | #define PACKAGE_BUGREPORT ""
      |         ^~~~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
config.h:180:9: warning: ‘PACKAGE_NAME’ redefined
  180 | #define PACKAGE_NAME ""
      |         ^~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
config.h:183:9: warning: ‘PACKAGE_STRING’ redefined
  183 | #define PACKAGE_STRING ""
      |         ^~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
config.h:186:9: warning: ‘PACKAGE_TARNAME’ redefined
  186 | #define PACKAGE_TARNAME ""
      |         ^~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
config.h:192:9: warning: ‘PACKAGE_VERSION’ redefined
  192 | #define PACKAGE_VERSION ""
      |         ^~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
~~~