### PR TITLE
build: fix -Wpointer-sign errors with libevent

### DIFF
--- a/connecter.c
+++ b/connecter.c
@@ -233,7 +233,7 @@ ssh_process_line(struct evbuffer *input, struct argument *arg)
 	struct ssh_state *state = arg->a_state;
 	while (1) {
 		size_t off = 0;
-		char *p = EVBUFFER_DATA(input);
+		char *p = (char *)EVBUFFER_DATA(input);
 
 		while (off < EVBUFFER_LENGTH(input)) {
 			if (*p == '\r') {
@@ -250,7 +250,7 @@ ssh_process_line(struct evbuffer *input, struct argument *arg)
 			return (-1);
 
 		off++;
-		p = EVBUFFER_DATA(input);
+		p = (char *)EVBUFFER_DATA(input);
 
 		state->nlines++;
 		if (state->firstline == NULL && isprint(*p))

--- a/http.c
+++ b/http.c
@@ -89,26 +89,26 @@ http_getheaders(struct bufferevent *bev, struct argument *arg)
 {
 	struct evbuffer *input = EVBUFFER_INPUT(bev);
 	size_t off;
-	char *p;
+	unsigned char *p;
 
-	while ((p = evbuffer_find(input, "\n", 1)) != NULL) {
-		off = (size_t)p - (size_t)EVBUFFER_DATA(input) + 1;
+	while ((p = evbuffer_find(input, (const unsigned char *)"\n", 1)) != NULL) {
+		off = (size_t)(p - EVBUFFER_DATA(input)) + 1;
 		if (off > 1 && *(p-1) == '\r')
 			*(p-1) = '\0';
 		*p = '\0';
 
-		if (strlen(EVBUFFER_DATA(input)) == 0) {
+		if (strlen((char *)EVBUFFER_DATA(input)) == 0) {
 			arg->a_flags |= HTTP_GOT_HEADERS;
 			evbuffer_drain(input, off);
 			break;
 		} else {
 			DFPRINTF((stderr, "Header: %s\n",
-				     EVBUFFER_DATA(input)));
+				     (char *)EVBUFFER_DATA(input)));
 		}
 
 		/* Check that we got an okay */
 		if (!(arg->a_flags & HTTP_GOT_OK)) {
-			if (http_response(EVBUFFER_DATA(input)) == -1) {
+			if (http_response((char *)EVBUFFER_DATA(input)) == -1) {
 				return (-1);
 			}
 			arg->a_flags |= HTTP_GOT_OK;
@@ -137,7 +137,7 @@ http_bufferanalyse(struct bufferevent *bev, struct argument *arg)
 	}
 
 	if (arg->a_flags & HTTP_GOT_HEADERS) {
-		if (evbuffer_find(input, "\r\n", 2) == NULL)
+		if (evbuffer_find(input, (const unsigned char *)"\r\n", 2) == NULL)
 			return (0);
 	
 		return (1);

--- a/scanssh.c
+++ b/scanssh.c
@@ -790,7 +790,7 @@ generate_random(struct generate *gen, char **pline)
 		uint32_t *tmp = (uint32_t *)digest;
 
 		MD5Init(&ctx);
-		MD5Update(&ctx, seed, strlen(seed));
+		MD5Update(&ctx, (const unsigned char *)seed, strlen(seed));
 		MD5Final(digest, &ctx);
 
 		gen->gen_seed = 0;

--- a/socks.c
+++ b/socks.c
@@ -184,22 +184,22 @@ socks_bufferanalyse(struct bufferevent *bev, struct argument *arg)
 	struct socks_state *socks = arg->a_state;
 	size_t off;
 	char response[32];
-	char *p;
+	unsigned char *p;
 	
 	if (!socks->gotheaders) {
-		while ((p = evbuffer_find(input, "\n", 1)) != NULL) {
-			off = (size_t)p - (size_t)EVBUFFER_DATA(input) + 1;
+		while ((p = evbuffer_find(input, (const unsigned char *)"\n", 1)) != NULL) {
+			off = (size_t)(p - EVBUFFER_DATA(input)) + 1;
 			if (off > 0 && *(p-1) == '\r')
 				*(p-1) = '\0';
 			*p = '\0';
 
-			if (strlen(EVBUFFER_DATA(input)) == 0) {
+			if (strlen((char *)EVBUFFER_DATA(input)) == 0) {
 				socks->gotheaders = 1;
 				evbuffer_drain(input, off);
 				break;
 			} else {
-				DFPRINTF((stderr, "Header: %s\n",
-					     EVBUFFER_DATA(input)));
+			DFPRINTF((stderr, "Header: %s\n",
+				     (char *)EVBUFFER_DATA(input)));
 			}
 			evbuffer_drain(input, off);
 		}
@@ -208,10 +208,10 @@ socks_bufferanalyse(struct bufferevent *bev, struct argument *arg)
 	if (!socks->gotheaders)
 		return;
 
-	if (evbuffer_find(input, "\r\n", 2) == NULL)
+	if (evbuffer_find(input, (const unsigned char *)"\r\n", 2) == NULL)
 		return;
 
-	if (evbuffer_find(input, socks->word, strlen(socks->word)) != NULL) {
+	if (evbuffer_find(input, (const unsigned char *)socks->word, strlen(socks->word)) != NULL) {
 		snprintf(response, sizeof(response),
 		    "SOCKS v%d", socks->version);
 		socks->success = 1;

--- a/telnet.c
+++ b/telnet.c
@@ -92,21 +92,21 @@ telnet_makeconnect(struct bufferevent *bev, struct argument *arg)
 
 	socks_resolveaddress("www.google.com", &address);
 
-	if (evbuffer_find(input, CCPROXY, strlen(CCPROXY)) != NULL) {
+	if (evbuffer_find(input, (const unsigned char *)CCPROXY, strlen(CCPROXY)) != NULL) {
 		state->response = "telnet-proxy: CCproxy";
 		state->connect_wait = "OK!";
 		evbuffer_add_printf(EVBUFFER_OUTPUT(bev),
 		    "open %s:80\r\n", addr_ntoa(socks_dst_addr));
 		bufferevent_enable(bev, EV_WRITE);
 		return (1);
-	} else if (evbuffer_find(input, GATEWAY1, strlen(GATEWAY1)) != NULL) {
+	} else if (evbuffer_find(input, (const unsigned char *)GATEWAY1, strlen(GATEWAY1)) != NULL) {
 		state->response = "telnet-proxy: Gateway";
 		state->connect_wait = "Connected to:";
 		evbuffer_add_printf(EVBUFFER_OUTPUT(bev),
 		    "%s:80\r\n", addr_ntoa(socks_dst_addr));
 		bufferevent_enable(bev, EV_WRITE);
 		return (1);
-	} else if (evbuffer_find(input, GATEWAY2, strlen(GATEWAY2)) != NULL) {
+	} else if (evbuffer_find(input, (const unsigned char *)GATEWAY2, strlen(GATEWAY2)) != NULL) {
 		state->response = "telnet-proxy: Gateway";
 		/* 
 		 * We do not get a connection confirmation, just the echoed
@@ -117,7 +117,7 @@ telnet_makeconnect(struct bufferevent *bev, struct argument *arg)
 		    "%s:80\r\n", addr_ntoa(socks_dst_addr));
 		bufferevent_enable(bev, EV_WRITE);
 		return (1);
-	} else if (evbuffer_find(input, WINGATE, strlen(WINGATE)) != NULL) {
+	} else if (evbuffer_find(input, (const unsigned char *)WINGATE, strlen(WINGATE)) != NULL) {
 		state->response = "telnet-proxy: WinGate";
 		state->connect_wait = "...Connected";
 		evbuffer_add_printf(EVBUFFER_OUTPUT(bev),
@@ -176,7 +176,7 @@ telnet_readcb(struct bufferevent *bev, void *parameter)
 		if (res == -1) {
 			evbuffer_add(input, "", 1);
 			printres(arg, arg->a_ports[0].port, 
-			    EVBUFFER_DATA(input));
+			    (char *)EVBUFFER_DATA(input));
 			scanhost_return(bev, arg, 0);
 			return;
 		} else if (res == 1) {
@@ -184,7 +184,7 @@ telnet_readcb(struct bufferevent *bev, void *parameter)
 			bufferevent_disable(bev, EV_READ);
 		}
 	} else if (arg->a_flags & TELNET_READING_CONNECT) {
-		if (evbuffer_find(input, state->connect_wait,
+		if (evbuffer_find(input, (const unsigned char *)state->connect_wait,
 			strlen(state->connect_wait)) == NULL)
 			return;
 		evbuffer_drain(input, EVBUFFER_LENGTH(input));


### PR DESCRIPTION
The codebase treats data buffers as `char *`, but `libevent` uses `unsigned char *` for its evbuffer APIs. This caused extensive `-Wpointer-sign` warnings and errors during compilation.

~~~
gcc -DPACKAGE_NAME=\"scanssh\" -DPACKAGE_TARNAME=\"scanssh\" -DPACKAGE_VERSION=\"2.1.3.1\" -DPACKAGE_STRING=\"scanssh\ 2.1.3.1\" -DPACKAGE_BUGREPORT=\"https://github.com/ofalk/scanssh/issues\" -DPACKAGE_URL=\"\" -DPACKAGE=\"scanssh\" -DVERSION=\"2.1.3.1\" -DHAVE_INET_ATON=1 -DHAVE_INET_PTON=1 -DHAVE_STRSEP=1 -DHAVE_GETADDRINFO=1 -DHAVE_GETNAMEINFO=1 -DHAVE_STRLCPY=1 -DHAVE_STRLCAT=1 -DHAVE_ARC4RANDOM=1 -DHAVE_WARNX=1 -DHAVE_SYS_WAIT_H=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_FCNTL_H=1 -DHAVE_SYS_IOCTL_H=1 -DHAVE_SYS_TIME_H=1 -DHAVE_UNISTD_H=1 -DHAVE_FDMASK_IN_SELECT=1 -DHAVE_SOCKADDR_STORAGE=1 -DHAVE_STRUCT_ADDRINFO=1 -DHAVE_TIMERADD=1 -DHAVE_GETTIMEOFDAY=1 -DHAVE_SELECT=1 -DHAVE_SOCKET=1 -DHAVE_STRDUP=1 -DHAVE_STRERROR=1 -DHAVE_STRTOL=1 -DHAVE_SETEUID=1 -I.  -I./ -I./compat -I/usr/include -I/usr/include    -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer    -I/usr/include -c -o socks.o socks.c
socks.c: In function ‘socks_bufferanalyse’:
socks.c:190:50: warning: pointer targets in passing argument 2 of ‘evbuffer_find’ differ in signedness [-Wpointer-sign]
  190 |                 while ((p = evbuffer_find(input, "\n", 1)) != NULL) {
      |                                                  ^~~~
      |                                                  |
      |                                                  char *
In file included from /usr/include/event.h:72,
                 from socks.c:47:
/usr/include/event2/buffer_compat.h:108:76: note: expected ‘const unsigned char *’ but argument is of type ‘char *’
  108 | unsigned char *evbuffer_find(struct evbuffer *buffer, const unsigned char *what, size_t len);
      |                                                       ~~~~~~~~~~~~~~~~~~~~~^~~~
socks.c:190:27: warning: pointer targets in assignment from ‘unsigned char *’ to ‘char *’ differ in signedness [-Wpointer-sign]
  190 |                 while ((p = evbuffer_find(input, "\n", 1)) != NULL) {
      |                           ^
socks.c:196:36: warning: pointer targets in passing argument 1 of ‘strlen’ differ in signedness [-Wpointer-sign]
  196 |                         if (strlen(EVBUFFER_DATA(input)) == 0) {
      |                                    ^~~~~~~~~~~~~
      |                                    |
      |                                    unsigned char *
In file included from socks.c:43:
/usr/include/string.h:439:35: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
  439 | extern size_t strlen (const char *__s)
      |                       ~~~~~~~~~~~~^~~
socks.c:211:34: warning: pointer targets in passing argument 2 of ‘evbuffer_find’ differ in signedness [-Wpointer-sign]
  211 |         if (evbuffer_find(input, "\r\n", 2) == NULL)
      |                                  ^~~~~~
      |                                  |
      |                                  char *
/usr/include/event2/buffer_compat.h:108:76: note: expected ‘const unsigned char *’ but argument is of type ‘char *’
  108 | unsigned char *evbuffer_find(struct evbuffer *buffer, const unsigned char *what, size_t len);
      |                                                       ~~~~~~~~~~~~~~~~~~~~~^~~~
socks.c:214:39: warning: pointer targets in passing argument 2 of ‘evbuffer_find’ differ in signedness [-Wpointer-sign]
  214 |         if (evbuffer_find(input, socks->word, strlen(socks->word)) != NULL) {
      |                                  ~~~~~^~~~~~
      |                                       |
      |                                       char *
/usr/include/event2/buffer_compat.h:108:76: note: expected ‘const unsigned char *’ but argument is of type ‘char *’
  108 | unsigned char *evbuffer_find(struct evbuffer *buffer, const unsigned char *what, size_t len);
      |                                                       ~~~~~~~~~~~~~~~~~~~~~^~~~
(...)
~~~