### PR TITLE
http: fix missing User-Agent header in CONNECT request

### DIFF
--- a/http.c
+++ b/http.c
@@ -175,6 +175,7 @@ http_makeconnect(struct bufferevent *bev, struct argument *arg)
 
 	evbuffer_add_printf(EVBUFFER_OUTPUT(bev),
 	    "CONNECT %s:80 HTTP/1.0\r\n"
+	    "User-Agent: %s\r\n"
 	    "\r\n", addr_ntoa(socks_dst_addr), SSHUSERAGENT);
 	bufferevent_enable(bev, EV_WRITE);
 }


### PR DESCRIPTION
The `http_makeconnect` function was passing `SSHUSERAGENT` as an argument to evbuffer_add_printf, but the format string was missing the corresponding `"User-Agent: %s"` line. This resulted in a `-Wformat-extra-args` compiler warning and caused the User-Agent header to be omitted from the HTTP request.

~~~
http.c: In function ‘http_makeconnect’:
http.c:177:13: warning: too many arguments for format [-Wformat-extra-args]
  177 |             "CONNECT %s:80 HTTP/1.0\r\n"
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~