### PR TITLE
md5: fix incomplete clearing of sensitive context data

### DIFF
--- a/md5.c
+++ b/md5.c
@@ -171,7 +171,7 @@ MD5Final(digest, ctx)
 	putu32(ctx->buf[1], digest + 4);
 	putu32(ctx->buf[2], digest + 8);
 	putu32(ctx->buf[3], digest + 12);
-	memset(ctx, 0, sizeof(ctx));	/* In case it's sensitive */
+	memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
 }
 
 #ifndef ASM_MD5


### PR DESCRIPTION
The MD5Final function was incorrectly using `sizeof(ctx)` (the size of the pointer) instead of `sizeof(*ctx)` (the size of the structure) when clearing memory.

This resulted in only the first 4 or 8 bytes being zeroed out, leaving the majority of the MD5 context (potentially sensitive data) in memory. This patch corrects the size calculation to ensure the entire structure is cleared.

~~~
md5.c:174:30: warning: argument to ‘sizeof’ in ‘memset’ call is the same expression as the destination; did you mean to dereference it? [-Wsizeof-pointer-memaccess]
  174 |         memset(ctx, 0, sizeof(ctx));    /* In case it's sensitive */
      |                              ^
~~~