### PR TITLE
interface: replace deprecated pcap_lookupdev with pcap_findalldevs

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -95,8 +95,14 @@ interface_new(char *dev)
 		err(1, "%s: calloc", __func__);
 
 	if (dev == NULL) {
-		if ((dev = pcap_lookupdev(ebuf)) == NULL)
-			errx(1, "pcap_lookupdev: %s", ebuf);
+		pcap_if_t *alldevs;
+		if (pcap_findalldevs(&alldevs, ebuf) == -1)
+			errx(1, "pcap_findalldevs: %s", ebuf);
+		if (alldevs == NULL)
+			errx(1, "pcap_findalldevs: no interfaces found");
+		strlcpy(ebuf, alldevs->name, sizeof(ebuf));
+		pcap_freealldevs(alldevs);
+		dev = ebuf;
 	}
 
 	TAILQ_INSERT_TAIL(&interfaces, inter, next);


### PR DESCRIPTION
The pcap_lookupdev function is deprecated in modern libpcap versions due to thread-safety issues and potential buffer overflows.

~~~
interface.c: In function ‘interface_new’:
interface.c:98:17: warning: ‘pcap_lookupdev’ is deprecated: use 'pcap_findalldevs' and use the first device [-Wdeprecated-declarations]
   98 |                 if ((dev = pcap_lookupdev(ebuf)) == NULL)
      |                 ^~
In file included from /usr/include/pcap.h:43,
                 from interface.c:54:
/usr/include/pcap/pcap.h:444:18: note: declared here
  444 | PCAP_API char   *pcap_lookupdev(char *);
      |                  ^~~~~~~~~~~~~~
~~~