### PR TITLE
scanssh: verify return values of setuid/seteuid calls

### DIFF
--- a/scanssh.c
+++ b/scanssh.c
@@ -1183,9 +1183,11 @@ main(int argc, char **argv)
        
 	/* revoke privs */
 #ifdef HAVE_SETEUID
-        seteuid(getuid());
+	if (seteuid(getuid()) == -1)
+		err(1, "seteuid");
 #endif /* HAVE_SETEUID */
-        setuid(getuid());
+	if (setuid(getuid()) == -1)
+		err(1, "setuid");
 
 	/* Set up our port ranges */
 	if (ss_nports == 0) {


### PR DESCRIPTION
The compiler warned that the return values of setuid() and seteuid() were being ignored. This is a potential security risk; if dropping privileges fails, the application should terminate immediately rather than continuing execution with elevated permissions.

This patch adds checks to ensure these calls succeed, exiting with an error if they fail.

~~~
scanssh.c: In function ‘main’:
scanssh.c:1186:9: warning: ignoring return value of ‘seteuid’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1186 |         seteuid(getuid());
      |         ^~~~~~~~~~~~~~~~~
scanssh.c:1188:9: warning: ignoring return value of ‘setuid’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1188 |         setuid(getuid());
      |         ^~~~~~~~~~~~~~~~
~~~