### PR TITLE
build: add missing string-compat.h to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = scanssh
 
 scanssh_SOURCES = scanssh.c atomicio.c exclude.c connecter.c xmalloc.c \
 	interface.c socks.c http.c telnet.c exclude.h interface.h \
-	scanssh.h socks.h xmalloc.h
+	scanssh.h socks.h string-compat.h xmalloc.h
 scanssh_LDADD = @LIBOBJS@ @PCAPLIB@ @EVENTLIB@ @DNETLIB@
 CFLAGS = @CFLAGS@
 


### PR DESCRIPTION
I did `make dist` over clean `devel` branch to create a tarball and used it to build it in Fedora. Build is failing as `string-compat.h` is missing:

~~~
interface.c:58:10: fatal error: string-compat.h: No such file or directory
   58 | #include "string-compat.h"
      |          ^~~~~~~~~~~~~~~~~
(...)
~~~