### PR TITLE
adjust openbsd package versions to use %

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           usesh: true
-          prepare: pkg_add gcc-11.2.0p19 gmake autoconf-2.72p0 automake-1.18 libevent libdnet
+          prepare: pkg_add gcc%11 gmake autoconf%2.72 automake%1.18 libevent libdnet
           run: |
             AUTOCONF_VERSION=2.72 AUTOMAKE_VERSION=1.18 /usr/local/bin/autoreconf-2.72 -f -i
             ./configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           usesh: true
-          prepare: pkg_add gcc%11 gmake autoconf%2.72 automake%1.18 libevent libdnet
+          prepare: pkg_add gmake autoconf%2.72 automake%1.18 libevent libdnet
           run: |
             AUTOCONF_VERSION=2.72 AUTOMAKE_VERSION=1.18 /usr/local/bin/autoreconf-2.72 -f -i
             ./configure


### PR DESCRIPTION
where a package is available in multiple versions, pkg_add(1) allows specifying the 'branch' with %, this allows asking for "the current autoconf 2.72.xx" without specifying it more exactly.