### PR TITLE
man: update command-line options and improve usage()

### DIFF
--- a/scanssh.1
+++ b/scanssh.1
@@ -38,11 +38,14 @@
 .Sh SYNOPSIS
 .Nm scanssh
 .Op Fl VIERph
-.Op Fl s Ar scanners,...
-.Op Fl n Ar ports,...
-.Op Fl u Ar socks hosts,...
+.Op Fl s Ar scanners , Ns ...
+.Op Fl n Ar ports , Ns ...
+.Op Fl u Ar socks-hosts , Ns ...
 .Op Fl e Ar excludefile
-.Ar addresses...
+.Op Fl i Ar interface
+.Op Fl r Ar syn-rate
+.Op Fl m Ar max-scanqueue
+.Ar address Ns ...
 .Sh DESCRIPTION
 .Nm ScanSSH
 scans the given addresses and networks for running services.
@@ -62,7 +65,7 @@ address:
 .Bl -tag -width randomxnxxseedxxx
 .It random(n[,seed])/
 The random command selects random address from the address range
-specified. 
+specified.
 The arguments are as follows:
 .Ar n
 is the number of address to randomly create in the given network
@@ -106,12 +109,12 @@ open proxies.
 Specifies the local interface.
 .It Fl h
 Displays the usage of the program.
-.It Fl n Ar ports,...
+.It Fl n Ar ports , Ns ...
 Specifies the port numbers to scan.
 Ports are separated by commas.
 Each specified scanner is run for each port in this list.
 The default is 22.
-.It Fl u Ar socks hosts,...
+.It Fl u Ar socks-hosts , Ns ...
 A list of comma separated host:port pairs of SOCKS proxies that
 .Nm
 should use to scan through.
@@ -136,9 +139,25 @@ Detects telnet based proxy servers.
 .It Fl e Ar excludefile
 Specifies the file that contains the addresses to be excluded from the scan.
 The syntax is the same as for the addresses on the command line.
+.It Fl i Ar interface
+Call from network
+.Ar interface ,
+instead of an automatic default.
+.It Fl r Ar syn-rate
+Send SYNs every
+.Pf 1/ Ar syn-rate
+seconds.
+Default:
+.Sy 100 .
+.It Fl m Ar max-scanqueue
+Scan at most
+.Ar max-scanqueue
+hosts.
+Default:
+.Sy 100 .
 .El
 .Pp
-The output from 
+The output from
 .Nm
 contains only IP addresses.  However, the IP addresses can be
 converted to names with the
@@ -179,7 +198,7 @@ scanssh 'random(0,rsd)/split(1,2)/(192.168.0.0/16 10.1.0.0/24):22,80'
 .\" .Sh HISTORY
 .\" .Sh AUTHORS
 .Sh BUGS
-At the moment, 
+At the moment,
 .Nm
 leaves a one line entry in the log file of the ssh server.  It is
 probably not possible to avoid that.

--- a/scanssh.c
+++ b/scanssh.c
@@ -456,7 +456,7 @@ void
 usage(char *name)
 {
 	fprintf(stderr, 
-	    "%s: [-VIERhp] [-s scanners] [-n ports] [-e excludefile] [-i if] [-b alias] <IP address|network>...\n\n"
+	    "%s: [-VIERhp] [-s scanners] [-n ports] [-e excludefile] [-i if] [-u socks hosts] [-m maxfds] [-r syns] <IP address|network>...\n\n"
 	    "\t-V          print version number of scanssh,\n"
 	    "\t-I          do not send identification string,\n"
 	    "\t-E          exit if exclude file is missing,\n"
@@ -464,8 +464,10 @@ usage(char *name)
 	    "\t-p	       proxy detection mode; set scanners and ports,\n"
 	    "\t-n <port>   the port number to scan.\n"
 	    "\t-e <file>   exclude the IP addresses and networks in <file>,\n"
-	    "\t-b <alias>  specifies the IP alias to connect from,\n"
 	    "\t-i <if>     specifies the local interface,\n"
+	    "\t-u <hosts>  comma-separated list of SOCKS host:port proxies,\n"
+	    "\t-m <maxfds> maximum number of concurrent open sockets,\n"
+	    "\t-r <syns>   number of SYN probes sent per second,\n"
 	    "\t-h          this message.\n"
 	    "\t-s <modes>  uses the following modules for scanning:\n",
 	    name);


### PR DESCRIPTION
This patch improves the `scanssh.1` manual page by:

- Updating the SYNOPSIS to list all supported flags (`-i`, `-r`, `-m`)
- Documenting the previously undocumented options `-i` (interface), `-r` (SYN rate), and `-m` (max scan queue)
- Minor formatting cleanups (comma spacing, `Ns` macros, repeated whitespace)

It also updates the `usage()` output in `scanssh.c` to correctly document the `-u` (SOCKS proxies), `-m` (max fds), and `-r` (SYN probes) options.  
In addition to that, it removes outdated `-b <alias>` reference (-b is not implemented in option parsing).

CC: @nabijaczleweli